### PR TITLE
feat: add CompanyName enum and Publisher class with character management

### DIFF
--- a/cbl/src/main/java/com/team5/cbl/CompanyName.java
+++ b/cbl/src/main/java/com/team5/cbl/CompanyName.java
@@ -1,0 +1,18 @@
+package com.team5.cbl;
+
+public enum CompanyName {
+     
+    MARVEL_COMICS("Marvel Comics"),
+    DC_COMICS( "DC Comics"),
+    IMAGE_COMICS( "Image Comics"),
+    DARK_HORSE_COMICS( "Dark Horse Comics"),
+    IDW_PUBLISHING( "IDW Publishing"),
+    VALIANT_ENTERTAINMENT( "Valiant Entertainment"),
+    BOOM_STUDIOS( "Boom Studios");
+
+        private final String displayName;
+
+    CompanyName(String displayName){
+        this.displayName = displayName;
+    }
+}

--- a/cbl/src/main/java/com/team5/cbl/CompanyName.java
+++ b/cbl/src/main/java/com/team5/cbl/CompanyName.java
@@ -1,18 +1,17 @@
 package com.team5.cbl;
 
 public enum CompanyName {
-     
-    MARVEL_COMICS("Marvel Comics"),
-    DC_COMICS( "DC Comics"),
-    IMAGE_COMICS( "Image Comics"),
-    DARK_HORSE_COMICS( "Dark Horse Comics"),
-    IDW_PUBLISHING( "IDW Publishing"),
-    VALIANT_ENTERTAINMENT( "Valiant Entertainment"),
-    BOOM_STUDIOS( "Boom Studios");
+  MARVEL_COMICS("Marvel Comics"),
+  DC_COMICS("DC Comics"),
+  IMAGE_COMICS("Image Comics"),
+  DARK_HORSE_COMICS("Dark Horse Comics"),
+  IDW_PUBLISHING("IDW Publishing"),
+  VALIANT_ENTERTAINMENT("Valiant Entertainment"),
+  BOOM_STUDIOS("Boom Studios");
 
-        private final String displayName;
+  private final String displayName;
 
-    CompanyName(String displayName){
-        this.displayName = displayName;
-    }
+  CompanyName(String displayName) {
+    this.displayName = displayName;
+  }
 }

--- a/cbl/src/main/java/com/team5/cbl/Publisher.java
+++ b/cbl/src/main/java/com/team5/cbl/Publisher.java
@@ -4,17 +4,17 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class Publisher {
-  private String companyName;
+  private CompanyName companyName;
   private final List<String> characters; // Make final
 
   // Constructor with company name only
-  public Publisher(String companyName) {
+  public Publisher(CompanyName companyName) {
     this.companyName = companyName;
     this.characters = new ArrayList<>();
   }
 
   // Constructor with company name and characters list
-  public Publisher(String companyName, List<String> characters) {
+  public Publisher(CompanyName companyName, List<String> characters) {
     this.companyName = companyName;
     this.characters = new ArrayList<>();
     if (characters != null) {
@@ -23,12 +23,12 @@ public class Publisher {
   }
 
   // Getter for company name
-  public String getCompanyName() {
+  public CompanyName getCompanyName() {
     return companyName;
   }
 
   // Setter for company name
-  public void setCompanyName(String companyName) {
+  public void setCompanyName(CompanyName companyName) {
     this.companyName = companyName;
   }
 

--- a/cbl/src/main/java/com/team5/cbl/Publisher.java
+++ b/cbl/src/main/java/com/team5/cbl/Publisher.java
@@ -1,0 +1,60 @@
+package com.team5.cbl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Publisher {
+    private String companyName;
+    private final List<String> characters; // Make final
+
+    // Constructor with company name only
+    public Publisher(String companyName) {
+        this.companyName = companyName;
+        this.characters = new ArrayList<>();
+    }
+
+    // Constructor with company name and characters list
+    public Publisher(String companyName, List<String> characters) {
+        this.companyName = companyName;
+        this.characters = new ArrayList<>();
+        if (characters != null) {
+            this.characters.addAll(characters);
+        }
+    }
+
+    // Getter for company name
+    public String getCompanyName() {
+        return companyName;
+    }
+
+    // Setter for company name
+    public void setCompanyName(String companyName) {
+        this.companyName = companyName;
+    }
+
+    // Getter for characters (returns defensive copy)
+    public List<String> getCharacters() {
+        return new ArrayList<>(characters);
+    }
+
+    // Setter for characters (clears and repopulates existing list)
+    public void setCharacters(List<String> characters) {
+        this.characters.clear();
+        if (characters != null) {
+            this.characters.addAll(characters);
+        }
+    }
+
+    // Add a character if it doesn't already exist
+    public void addCharacter(String character) {
+        if (character != null && !characters.contains(character)) {
+            characters.add(character);
+        }
+    }
+
+    // Check if publisher has a specific character
+    public boolean hasCharacter(String character) {
+        return character != null && characters.contains(character);
+    }
+}
+

--- a/cbl/src/main/java/com/team5/cbl/Publisher.java
+++ b/cbl/src/main/java/com/team5/cbl/Publisher.java
@@ -4,57 +4,56 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class Publisher {
-    private String companyName;
-    private final List<String> characters; // Make final
+  private String companyName;
+  private final List<String> characters; // Make final
 
-    // Constructor with company name only
-    public Publisher(String companyName) {
-        this.companyName = companyName;
-        this.characters = new ArrayList<>();
-    }
+  // Constructor with company name only
+  public Publisher(String companyName) {
+    this.companyName = companyName;
+    this.characters = new ArrayList<>();
+  }
 
-    // Constructor with company name and characters list
-    public Publisher(String companyName, List<String> characters) {
-        this.companyName = companyName;
-        this.characters = new ArrayList<>();
-        if (characters != null) {
-            this.characters.addAll(characters);
-        }
+  // Constructor with company name and characters list
+  public Publisher(String companyName, List<String> characters) {
+    this.companyName = companyName;
+    this.characters = new ArrayList<>();
+    if (characters != null) {
+      this.characters.addAll(characters);
     }
+  }
 
-    // Getter for company name
-    public String getCompanyName() {
-        return companyName;
-    }
+  // Getter for company name
+  public String getCompanyName() {
+    return companyName;
+  }
 
-    // Setter for company name
-    public void setCompanyName(String companyName) {
-        this.companyName = companyName;
-    }
+  // Setter for company name
+  public void setCompanyName(String companyName) {
+    this.companyName = companyName;
+  }
 
-    // Getter for characters (returns defensive copy)
-    public List<String> getCharacters() {
-        return new ArrayList<>(characters);
-    }
+  // Getter for characters (returns defensive copy)
+  public List<String> getCharacters() {
+    return new ArrayList<>(characters);
+  }
 
-    // Setter for characters (clears and repopulates existing list)
-    public void setCharacters(List<String> characters) {
-        this.characters.clear();
-        if (characters != null) {
-            this.characters.addAll(characters);
-        }
+  // Setter for characters (clears and repopulates existing list)
+  public void setCharacters(List<String> characters) {
+    this.characters.clear();
+    if (characters != null) {
+      this.characters.addAll(characters);
     }
+  }
 
-    // Add a character if it doesn't already exist
-    public void addCharacter(String character) {
-        if (character != null && !characters.contains(character)) {
-            characters.add(character);
-        }
+  // Add a character if it doesn't already exist
+  public void addCharacter(String character) {
+    if (character != null && !characters.contains(character)) {
+      characters.add(character);
     }
+  }
 
-    // Check if publisher has a specific character
-    public boolean hasCharacter(String character) {
-        return character != null && characters.contains(character);
-    }
+  // Check if publisher has a specific character
+  public boolean hasCharacter(String character) {
+    return character != null && characters.contains(character);
+  }
 }
-

--- a/cbl/src/test/java/com/team5/cbl/PublisherTests.java
+++ b/cbl/src/test/java/com/team5/cbl/PublisherTests.java
@@ -1,0 +1,128 @@
+package com.team5.cbl;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.BeforeEach;
+import static org.junit.jupiter.api.Assertions.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class PublisherTests {
+
+    private String testCompanyName;
+    private List<String> testCharacters; 
+
+    @BeforeEach
+    void setUp() {
+        testCompanyName = "Marvel Comics";
+        testCharacters = new ArrayList<>(Arrays.asList("Spider-Man", "Iron Man", "Captain America"));
+    }
+
+    @Test
+    @DisplayName("Test constructor with company name and character list")
+    void testConstructorWithCharacters(){
+        Publisher publisher = new Publisher(testCompanyName, testCharacters);
+
+        assertEquals(testCompanyName, publisher.getCompanyName());
+        assertNotNull(publisher.getCharacters());
+        assertFalse(publisher.getCharacters().isEmpty());
+    }
+
+    @Test
+    @DisplayName("Test getCompanyName method")
+    void testGetCompanyName(){
+        Publisher publisher = new Publisher(testCompanyName, testCharacters);
+        assertEquals(testCompanyName, publisher.getCompanyName());
+    }
+
+    @Test
+    @DisplayName("Test setCompanyName method")
+    void testSetCompanyName() {
+        Publisher publisher = new Publisher(testCompanyName, testCharacters);
+        String newCompanyName = "DC Comics";
+
+        publisher.setCompanyName(newCompanyName);
+        assertEquals(newCompanyName, publisher.getCompanyName());
+    }
+
+    @Test
+    @DisplayName("Test setCharacters method")
+    void testSetCharacters() { 
+        Publisher publisher = new Publisher(testCompanyName);
+        List<String> newCharacters = new ArrayList<>(Arrays.asList("Batman", "Superman", "Wonder Woman"));
+
+        publisher.setCharacters(newCharacters);
+        assertEquals(newCharacters, publisher.getCharacters());
+
+        newCharacters.add("Flash");
+        assertFalse(publisher.getCharacters().contains("Flash"));
+    }
+
+    @Test
+    @DisplayName("Test addCharacter - new character")
+    void testAddCharacterNew() {
+        Publisher publisher = new Publisher(testCompanyName, testCharacters);
+        String newCharacter = "Black Widow";
+
+        publisher.addCharacter(newCharacter);
+        assertTrue(publisher.hasCharacter(newCharacter));
+        assertEquals(4, publisher.getCharacters().size());
+    }
+
+    @Test
+    @DisplayName("Test addCharacter - duplicate character")
+    void testAddCharacterDuplicate() {
+        Publisher publisher = new Publisher(testCompanyName, testCharacters);
+        String existingCharacter = "Spider-Man";
+
+        publisher.addCharacter(existingCharacter);
+        assertTrue(publisher.hasCharacter(existingCharacter));
+        assertEquals(3, publisher.getCharacters().size());
+    }
+
+    @Test
+    @DisplayName("Test hasCharacter - existing character")
+    void testHasCharacterExisting() {
+        Publisher publisher = new Publisher(testCompanyName, testCharacters);
+        assertTrue(publisher.hasCharacter("Spider-Man"));
+        assertTrue(publisher.hasCharacter("Iron Man"));
+        assertTrue(publisher.hasCharacter("Captain America"));
+    }
+
+    @Test
+    @DisplayName("Test hasCharacter - non-existing character")
+    void testHasCharacterNonExisting() {
+        Publisher publisher = new Publisher(testCompanyName, testCharacters);
+        assertFalse(publisher.hasCharacter("Batman"));
+        assertFalse(publisher.hasCharacter("Superman"));
+    }
+
+    @Test
+    @DisplayName("Test with null company name")
+    void testNullCompanyName() {
+        assertDoesNotThrow(() -> {
+            Publisher publisher = new Publisher(null, testCharacters);
+            assertNotNull(publisher.getCharacters());
+        });
+    }
+
+    @Test
+    @DisplayName("Test with null characters list")
+    void testNullCharactersList() {
+        assertDoesNotThrow(() -> {
+            Publisher publisher = new Publisher(testCompanyName, null);
+            assertNotNull(publisher.getCharacters());
+        });
+    }
+
+    @Test
+    @DisplayName("Test with empty characters list")
+    void testEmptyCharactersList() {
+        List<String> emptyList = new ArrayList<>();
+        Publisher publisher = new Publisher(testCompanyName, emptyList);
+        
+        assertTrue(publisher.getCharacters().isEmpty());
+        assertFalse(publisher.hasCharacter("Any Character"));
+    }
+}

--- a/cbl/src/test/java/com/team5/cbl/PublisherTests.java
+++ b/cbl/src/test/java/com/team5/cbl/PublisherTests.java
@@ -1,128 +1,132 @@
 package com.team5.cbl;
 
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.BeforeEach;
 import static org.junit.jupiter.api.Assertions.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 public class PublisherTests {
 
-    private String testCompanyName;
-    private List<String> testCharacters; 
+  private String testCompanyName;
+  private List<String> testCharacters;
 
-    @BeforeEach
-    void setUp() {
-        testCompanyName = "Marvel Comics";
-        testCharacters = new ArrayList<>(Arrays.asList("Spider-Man", "Iron Man", "Captain America"));
-    }
+  @BeforeEach
+  void setUp() {
+    testCompanyName = "Marvel Comics";
+    testCharacters = new ArrayList<>(Arrays.asList("Spider-Man", "Iron Man", "Captain America"));
+  }
 
-    @Test
-    @DisplayName("Test constructor with company name and character list")
-    void testConstructorWithCharacters(){
-        Publisher publisher = new Publisher(testCompanyName, testCharacters);
+  @Test
+  @DisplayName("Test constructor with company name and character list")
+  void testConstructorWithCharacters() {
+    Publisher publisher = new Publisher(testCompanyName, testCharacters);
 
-        assertEquals(testCompanyName, publisher.getCompanyName());
-        assertNotNull(publisher.getCharacters());
-        assertFalse(publisher.getCharacters().isEmpty());
-    }
+    assertEquals(testCompanyName, publisher.getCompanyName());
+    assertNotNull(publisher.getCharacters());
+    assertFalse(publisher.getCharacters().isEmpty());
+  }
 
-    @Test
-    @DisplayName("Test getCompanyName method")
-    void testGetCompanyName(){
-        Publisher publisher = new Publisher(testCompanyName, testCharacters);
-        assertEquals(testCompanyName, publisher.getCompanyName());
-    }
+  @Test
+  @DisplayName("Test getCompanyName method")
+  void testGetCompanyName() {
+    Publisher publisher = new Publisher(testCompanyName, testCharacters);
+    assertEquals(testCompanyName, publisher.getCompanyName());
+  }
 
-    @Test
-    @DisplayName("Test setCompanyName method")
-    void testSetCompanyName() {
-        Publisher publisher = new Publisher(testCompanyName, testCharacters);
-        String newCompanyName = "DC Comics";
+  @Test
+  @DisplayName("Test setCompanyName method")
+  void testSetCompanyName() {
+    Publisher publisher = new Publisher(testCompanyName, testCharacters);
+    String newCompanyName = "DC Comics";
 
-        publisher.setCompanyName(newCompanyName);
-        assertEquals(newCompanyName, publisher.getCompanyName());
-    }
+    publisher.setCompanyName(newCompanyName);
+    assertEquals(newCompanyName, publisher.getCompanyName());
+  }
 
-    @Test
-    @DisplayName("Test setCharacters method")
-    void testSetCharacters() { 
-        Publisher publisher = new Publisher(testCompanyName);
-        List<String> newCharacters = new ArrayList<>(Arrays.asList("Batman", "Superman", "Wonder Woman"));
+  @Test
+  @DisplayName("Test setCharacters method")
+  void testSetCharacters() {
+    Publisher publisher = new Publisher(testCompanyName);
+    List<String> newCharacters =
+        new ArrayList<>(Arrays.asList("Batman", "Superman", "Wonder Woman"));
 
-        publisher.setCharacters(newCharacters);
-        assertEquals(newCharacters, publisher.getCharacters());
+    publisher.setCharacters(newCharacters);
+    assertEquals(newCharacters, publisher.getCharacters());
 
-        newCharacters.add("Flash");
-        assertFalse(publisher.getCharacters().contains("Flash"));
-    }
+    newCharacters.add("Flash");
+    assertFalse(publisher.getCharacters().contains("Flash"));
+  }
 
-    @Test
-    @DisplayName("Test addCharacter - new character")
-    void testAddCharacterNew() {
-        Publisher publisher = new Publisher(testCompanyName, testCharacters);
-        String newCharacter = "Black Widow";
+  @Test
+  @DisplayName("Test addCharacter - new character")
+  void testAddCharacterNew() {
+    Publisher publisher = new Publisher(testCompanyName, testCharacters);
+    String newCharacter = "Black Widow";
 
-        publisher.addCharacter(newCharacter);
-        assertTrue(publisher.hasCharacter(newCharacter));
-        assertEquals(4, publisher.getCharacters().size());
-    }
+    publisher.addCharacter(newCharacter);
+    assertTrue(publisher.hasCharacter(newCharacter));
+    assertEquals(4, publisher.getCharacters().size());
+  }
 
-    @Test
-    @DisplayName("Test addCharacter - duplicate character")
-    void testAddCharacterDuplicate() {
-        Publisher publisher = new Publisher(testCompanyName, testCharacters);
-        String existingCharacter = "Spider-Man";
+  @Test
+  @DisplayName("Test addCharacter - duplicate character")
+  void testAddCharacterDuplicate() {
+    Publisher publisher = new Publisher(testCompanyName, testCharacters);
+    String existingCharacter = "Spider-Man";
 
-        publisher.addCharacter(existingCharacter);
-        assertTrue(publisher.hasCharacter(existingCharacter));
-        assertEquals(3, publisher.getCharacters().size());
-    }
+    publisher.addCharacter(existingCharacter);
+    assertTrue(publisher.hasCharacter(existingCharacter));
+    assertEquals(3, publisher.getCharacters().size());
+  }
 
-    @Test
-    @DisplayName("Test hasCharacter - existing character")
-    void testHasCharacterExisting() {
-        Publisher publisher = new Publisher(testCompanyName, testCharacters);
-        assertTrue(publisher.hasCharacter("Spider-Man"));
-        assertTrue(publisher.hasCharacter("Iron Man"));
-        assertTrue(publisher.hasCharacter("Captain America"));
-    }
+  @Test
+  @DisplayName("Test hasCharacter - existing character")
+  void testHasCharacterExisting() {
+    Publisher publisher = new Publisher(testCompanyName, testCharacters);
+    assertTrue(publisher.hasCharacter("Spider-Man"));
+    assertTrue(publisher.hasCharacter("Iron Man"));
+    assertTrue(publisher.hasCharacter("Captain America"));
+  }
 
-    @Test
-    @DisplayName("Test hasCharacter - non-existing character")
-    void testHasCharacterNonExisting() {
-        Publisher publisher = new Publisher(testCompanyName, testCharacters);
-        assertFalse(publisher.hasCharacter("Batman"));
-        assertFalse(publisher.hasCharacter("Superman"));
-    }
+  @Test
+  @DisplayName("Test hasCharacter - non-existing character")
+  void testHasCharacterNonExisting() {
+    Publisher publisher = new Publisher(testCompanyName, testCharacters);
+    assertFalse(publisher.hasCharacter("Batman"));
+    assertFalse(publisher.hasCharacter("Superman"));
+  }
 
-    @Test
-    @DisplayName("Test with null company name")
-    void testNullCompanyName() {
-        assertDoesNotThrow(() -> {
-            Publisher publisher = new Publisher(null, testCharacters);
-            assertNotNull(publisher.getCharacters());
+  @Test
+  @DisplayName("Test with null company name")
+  void testNullCompanyName() {
+    assertDoesNotThrow(
+        () -> {
+          Publisher publisher = new Publisher(null, testCharacters);
+          assertNotNull(publisher.getCharacters());
         });
-    }
+  }
 
-    @Test
-    @DisplayName("Test with null characters list")
-    void testNullCharactersList() {
-        assertDoesNotThrow(() -> {
-            Publisher publisher = new Publisher(testCompanyName, null);
-            assertNotNull(publisher.getCharacters());
+  @Test
+  @DisplayName("Test with null characters list")
+  void testNullCharactersList() {
+    assertDoesNotThrow(
+        () -> {
+          Publisher publisher = new Publisher(testCompanyName, null);
+          assertNotNull(publisher.getCharacters());
         });
-    }
+  }
 
-    @Test
-    @DisplayName("Test with empty characters list")
-    void testEmptyCharactersList() {
-        List<String> emptyList = new ArrayList<>();
-        Publisher publisher = new Publisher(testCompanyName, emptyList);
-        
-        assertTrue(publisher.getCharacters().isEmpty());
-        assertFalse(publisher.hasCharacter("Any Character"));
-    }
+  @Test
+  @DisplayName("Test with empty characters list")
+  void testEmptyCharactersList() {
+    List<String> emptyList = new ArrayList<>();
+    Publisher publisher = new Publisher(testCompanyName, emptyList);
+
+    assertTrue(publisher.getCharacters().isEmpty());
+    assertFalse(publisher.hasCharacter("Any Character"));
+  }
 }


### PR DESCRIPTION
This code implements a Publisher class for managing comic book publishers and their associated characters, along with comprehensive unit tests to verify its functionality.

The Publisher class represents a comic book publisher entity with the following key features:
companyName (String) - The name of the publishing company
characters (List<String>) - A list of character names owned by the publisher
Create a publisher with just a company name (empty character list)
Create a publisher with both company name and initial character list

-Test didn't past locally going to continue working on it